### PR TITLE
Add SDK size to System Requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ _To run the SDK a Verisoul Project ID is required._ Schedule a call [here](https
 - Xcode 15.0 or higher
 - Swift 5.9 or higher
 - CocoaPods 1.10+ (if using CocoaPods)
+- SDK Size: ~480 KB
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Adds SDK size (~480 KB) to the System Requirements section of the README

## Test plan
- [ ] Verify README renders correctly on GitHub

Made with [Cursor](https://cursor.com)